### PR TITLE
Even more custom sprite

### DIFF
--- a/src/engine_render.h
+++ b/src/engine_render.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #define KEEPSPRITE_LENGTH 9149
 #define KEEPERSPRITE_ADD_OFFSET 16384
-#define KEEPERSPRITE_ADD_NUM 8192
+#define KEEPERSPRITE_ADD_NUM 16384
 
 struct EngineCoord { // sizeof = 28
   long view_width; // X screen position, probably not a width


### PR DESCRIPTION
KEEPERSPRITE_ADD_NUM from 8192 to 16384.
I know the recent change allowed 8192, I make this as a reminder, there is no need for it for now.